### PR TITLE
Fix PostgreSQL procedure calls for enrolment transfers

### DIFF
--- a/farms-legacy/src/main/java/ca/bc/gov/srm/farm/dao/VersionDAO.java
+++ b/farms-legacy/src/main/java/ca/bc/gov/srm/farm/dao/VersionDAO.java
@@ -422,7 +422,7 @@ public class VersionDAO {
 
       try (DAOStoredProcedure proc = new DAOStoredProcedure(conn,
             PACKAGE_NAME + "." + IMPORT_FAILURE_PROC,
-            IMPORT_FAILURE_PARAM, true);) {
+            IMPORT_FAILURE_PARAM, false);) {
 
         int c = 1;
         proc.setLong(c++, pImportVersionId == null ? null : pImportVersionId.longValue());
@@ -467,7 +467,7 @@ public class VersionDAO {
 
       try (DAOStoredProcedure proc = new DAOStoredProcedure(conn,
             PACKAGE_NAME + "." + IMPORT_COMPLETE_PROC,
-            IMPORT_COMPLETE_PARAM, true);) {
+            IMPORT_COMPLETE_PARAM, false);) {
         
         int c = 1;
         proc.setLong(c++, pImportVersionId == null ? null : pImportVersionId.longValue());


### PR DESCRIPTION

This PR fixes an error in the Legacy FARM Enrolment Notice Workflow.

The issue occurred when changing a scenario from `In Progress` to
`Enrolment Notice Complete`. Legacy FARM successfully calculated and saved the
enrolment, but failed while marking the generated `ENROL` job as complete.
Because of this failure, the `XENROL` transfer to CORE/Dataverse was never
scheduled.

The application log showed:

```text
ERROR: farms_version_pkg.import_complete(
    bigint,
    character varying,
    character varying
) is a procedure